### PR TITLE
feature/ci-automation-tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,30 @@
+name: テストをDocker Composeで実行
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: コードをチェックアウト
+        uses: actions/checkout@v4
+
+      - name: Docker Composeをセットアップ
+        run: |
+          docker compose -f compose.yml -f compose.dev.yml up -d --build
+
+      - name: コンテナ内でテストを実行
+        run: |
+          docker compose exec python sh /home/work/apisource/tests/run_tests.sh
+
+      - name: Docker Composeを終了
+        if: always()
+        run: |
+          docker compose down --rmi local -v


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate running tests using Docker Compose. The workflow is triggered on pushes and pull requests to the `main` branch.

### New GitHub Actions workflow:

* `.github/workflows/run-tests.yml`: Introduced a workflow named "テストをDocker Composeで実行" that:
  - Checks out the code using the `actions/checkout@v4` action.
  - Sets up and builds the Docker Compose environment using `compose.yml` and `compose.dev.yml`.
  - Executes tests inside a container using a shell script located at `/home/work/apisource/tests/run_tests.sh`.
  - Cleans up the Docker Compose environment after the tests, removing images and volumes.

close #18 