### PR TITLE
feature/自動テストに失敗したときにCIを失敗させる

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,6 +26,7 @@ jobs:
       - name: テスト完了を確認するためのコンテナのヘルスチェック
         run: |
           count=0
+          result=0
           until [ $(docker inspect --format='{{.State.Health.Status}}' python_service) = "healthy" ] || \
                 [ $(docker inspect --format='{{.State.Health.Status}}' python_service) = "unhealthy" ] || \
                 [ $count -eq 25 ]; do
@@ -35,14 +36,24 @@ jobs:
           done
           if [ $(docker inspect --format='{{.State.Health.Status}}' python_service) = "unhealthy" ]; then
             echo "テストが失敗しました。"
+            result=1
           fi
           if [ $count -eq 25 ]; then
             echo "制限時間内にテストが完了しませんでした。"
+            result=1
           fi
+          echo $result > result.txt
 
       - name: テスト結果のログを表示
         run: |
           docker compose logs python
+
+      - name: テスト失敗時にCIを失敗させる
+        run: |
+          if [ -f result.txt ] && [ $(cat result.txt) -ne 0 ]; then
+            echo "CIを失敗させます。"
+            exit 1
+          fi
 
       - name: Docker Composeでサービスを停止
         run: |

--- a/python/apisource/tests/test_main.py
+++ b/python/apisource/tests/test_main.py
@@ -82,9 +82,3 @@ def test_extract_audio_empty_file():
 
     assert response.status_code == 500
     assert response.json()["message"] == "Audio extraction failed"
-
-def test_dummy_failure():
-    """
-    必ず失敗するダミーのテストケース。
-    """
-    assert False, "このテストは必ず失敗します"

--- a/python/apisource/tests/test_main.py
+++ b/python/apisource/tests/test_main.py
@@ -82,3 +82,9 @@ def test_extract_audio_empty_file():
 
     assert response.status_code == 500
     assert response.json()["message"] == "Audio extraction failed"
+
+def test_dummy_failure():
+    """
+    必ず失敗するダミーのテストケース。
+    """
+    assert False, "このテストは必ず失敗します"


### PR DESCRIPTION
このプルリクエストでは、`.github/workflows/run-tests.yml` ファイルを更新して、CI ワークフロー内のテスト結果の処理を改善しています。この変更により、テストの失敗やタイムアウトが適切に記録され、必要に応じて CI プロセスが失敗するようになります。

### CI ワークフローへの改善点:

* ヘルスチェックプロセスの結果を追跡するために `result` 変数を追加しました。テストが失敗または時間を超過した場合、この変数は `1` に設定されます。
* `result` 値を参照できるように `result.txt` ファイルに書き込むステップを追加しました。
* `result.txt` が失敗を示している場合に CI プロセスを明示的に失敗させる新しいステップを追加しました。これにより、CI はテストの状態を正確に反映します。

close #25 